### PR TITLE
Reverted Gateway auth to v1 to easily bring terraform back inline

### DIFF
--- a/Rumpole.sln.DotSettings.user
+++ b/Rumpole.sln.DotSettings.user
@@ -5,6 +5,7 @@
 	
 	
 	
+	
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=5640fdc9_002D4099_002D4d9f_002Da001_002D38161bdef697/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;Solution /&gt;&#xD;
 &lt;/SessionState&gt;</s:String>

--- a/rumpole-gateway/.gitignore
+++ b/rumpole-gateway/.gitignore
@@ -3,6 +3,7 @@
 
 # Azure Functions localsettings file
 local.settings.json
+local.settings.json.backup
 
 # User-specific files
 *.suo
@@ -295,3 +296,4 @@ __queuestorage__
 
 # Ignore code-workspaces
 *.code-workspace
+/local.settings.json.backup

--- a/rumpole-gateway/Domain/RumpolePipeline/DocumentStatus.cs
+++ b/rumpole-gateway/Domain/RumpolePipeline/DocumentStatus.cs
@@ -8,7 +8,12 @@
 		NotFoundInCDE,
 		UnableToConvertToPdf,
 		UnexpectedFailure,
-		OcrAndIndexFailure
+		OcrAndIndexFailure,
+		DocumentEvaluated,
+		DocumentRemovedFromSearchIndex,
+		UnexpectedSearchIndexRemovalFailure,
+		SearchIndexUpdateFailure,
+		UnableToEvaluateDocument
 	}
 }
 

--- a/rumpole-gateway/Domain/RumpolePipeline/TrackerStatus.cs
+++ b/rumpole-gateway/Domain/RumpolePipeline/TrackerStatus.cs
@@ -2,11 +2,14 @@
 {
 	public enum TrackerStatus
 	{
+		Initialised,
 		NotStarted,
 		Running,
+		// ReSharper disable once InconsistentNaming
 		NoDocumentsFoundInCDE,
 		Completed,
-		Failed
+		Failed,
+		UnableToEvaluateExistingDocuments
 	}
 }
 

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -58,6 +58,18 @@ resource "azurerm_function_app" "fa_rumpole" {
   identity {
     type = "SystemAssigned"
   }
+
+  auth_settings {
+    enabled                       = true
+    issuer                        = "https://sts.windows.net/${data.azurerm_client_config.current.tenant_id}/"
+    unauthenticated_client_action = "RedirectToLoginPage"
+    default_provider              = "AzureActiveDirectory"
+    active_directory {
+      client_id         = azuread_application.fa_rumpole.application_id
+      client_secret     = azuread_application_password.faap_rumpole_app_service.value
+      client_secret_setting_name = ""
+      allowed_audiences = ["https://CPSGOVUK.onmicrosoft.com/fa-${local.resource_name}-gateway"]
+  }
 	
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
This will allow the restoration of the authsettings section to the function definition. Some enum additional values in preparation for the upcoming pipeline changes.